### PR TITLE
#5819 Add security context and OpenShift support to deployment templates

### DIFF
--- a/charts/governor/templates/deployment-api.yaml
+++ b/charts/governor/templates/deployment-api.yaml
@@ -20,8 +20,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.api.securityContext }}
       securityContext:
         {{- toYaml .Values.api.securityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.api.name }}
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"

--- a/charts/governor/templates/deployment-api.yaml
+++ b/charts/governor/templates/deployment-api.yaml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       {{- with .Values.api.securityContext }}
       securityContext:
-        {{- toYaml .Values.api.securityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Values.api.name }}

--- a/charts/governor/templates/deployment-front.yaml
+++ b/charts/governor/templates/deployment-front.yaml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       {{- with .Values.front.securityContext }}
       securityContext:
-        {{- toYaml .Values.front.securityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Values.front.name }}

--- a/charts/governor/templates/deployment-front.yaml
+++ b/charts/governor/templates/deployment-front.yaml
@@ -20,6 +20,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.front.securityContext }}
+      securityContext:
+        {{- toYaml .Values.front.securityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.front.name }}
           image: "{{ .Values.front.image.repository }}:{{ .Values.front.image.tag | default .Chart.AppVersion }}"
@@ -38,7 +42,7 @@ spec:
                 name: {{ .Values.front.name }}-configmap
             - secretRef:
                 name: {{ .Values.front.name }}-secret
-          {{- end}}
+          {{- end }}
           env:
             {{- range .Values.front.container.secretenv }}
             - name: {{ .name }}
@@ -46,13 +50,31 @@ spec:
                 secretKeyRef:
                   name: {{ .valueFrom.secretKeyRef.name }}
                   key: {{ .valueFrom.secretKeyRef.key }}
-            {{- end}}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /
               port: {{ .Values.front.container.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
+          {{- if .Values.openShiftEnabled }}
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+            - name: app-data
+              mountPath: /apps/governor
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+          {{- end }}
+      volumes:
+        {{- if .Values.openShiftEnabled }}
+        - name: nginx-config
+          emptyDir: {}
+        - name: app-data
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/governor/values.yaml
+++ b/charts/governor/values.yaml
@@ -1,5 +1,6 @@
 mode: self-hosted
 sandbox: false
+openshiftEnabled: false
 
 api:
   name: governor-api


### PR DESCRIPTION
#5819

Introduce security context configurations for both API and front-end deployment templates. Enable support for OpenShift by adding volume mounts and volume definitions, along with a new configuration option in the values file.