### PR TITLE
[#8399] Enable Envoy hot reload for rotated internal TLS certs

### DIFF
--- a/charts/governor/templates/_helpers.tpl
+++ b/charts/governor/templates/_helpers.tpl
@@ -44,6 +44,15 @@ legacy "tdkAgents" key. Same merge semantics as governor.workerValues.
 {{- end -}}
 
 {{/*
+Envoy node identity required for SDS initialization.
+*/}}
+{{- define "governor.envoy.node" -}}
+node:
+  cluster: {{ printf "%s-envoy" .componentName | quote }}
+  id: {{ printf "%s.%s" .componentName .Release.Namespace | quote }}
+{{- end }}
+
+{{/*
 Envoy sidecar container template
 Usage: {{ include "governor.tlsInternal.sidecar" (dict "componentName" "api" "config" .Values.api "tlsInternal" .Values.tlsInternal "hasHttpPort" true "hasGrpcPort" true) }}
 */}}
@@ -153,6 +162,34 @@ Usage: {{ include "governor.tlsInternal.volumes" (dict "componentName" "api" "co
 {{- end }}
 
 {{/*
+Envoy file-based SDS secret documents for hot-reloading mounted cert-manager
+Secrets. These are consumed via path_config_source.
+*/}}
+{{- define "governor.envoy.downstreamTlsSdsSecret" -}}
+resources:
+  - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: downstream_tls_certificate
+    tls_certificate:
+      certificate_chain:
+        filename: /etc/envoy/certs/tls.crt
+      private_key:
+        filename: /etc/envoy/certs/tls.key
+      watched_directory:
+        path: /etc/envoy/certs
+{{- end }}
+
+{{- define "governor.envoy.upstreamValidationContextSdsSecret" -}}
+resources:
+  - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: upstream_validation_context
+    validation_context:
+      trusted_ca:
+        filename: /etc/envoy/ca/ca.crt
+      watched_directory:
+        path: /etc/envoy/ca
+{{- end }}
+
+{{/*
 Envoy HTTP router filter (used in all listeners)
 */}}
 {{- define "governor.envoy.httpRouter" -}}
@@ -170,11 +207,11 @@ transport_socket:
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
     common_tls_context:
-      tls_certificates:
-        - certificate_chain:
-            filename: /etc/envoy/certs/tls.crt
-          private_key:
-            filename: /etc/envoy/certs/tls.key
+      tls_certificate_sds_secret_configs:
+        - name: downstream_tls_certificate
+          sds_config:
+            path_config_source:
+              path: /etc/envoy/downstream_tls_certificate.yaml
 {{- end }}
 
 {{/*
@@ -186,9 +223,11 @@ transport_socket:
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
     common_tls_context:
-      validation_context:
-        trusted_ca:
-          filename: /etc/envoy/ca/ca.crt
+      validation_context_sds_secret_config:
+        name: upstream_validation_context
+        sds_config:
+          path_config_source:
+            path: /etc/envoy/upstream_validation_context.yaml
 {{- end }}
 
 {{/*

--- a/charts/governor/templates/configmap-envoy-api.yaml
+++ b/charts/governor/templates/configmap-envoy-api.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "governor.selectorLabels" . | nindent 4 }}
 data:
   envoy.yaml: |
+    {{- include "governor.envoy.node" (dict "componentName" .Values.api.name "Release" .Release) | nindent 4 }}
     admin:
       address:
         socket_address:
@@ -99,4 +100,6 @@ data:
                         socket_address:
                           address: 127.0.0.1
                           port_value: {{ .Values.api.container.grpcPort }}
+  downstream_tls_certificate.yaml: |
+    {{- include "governor.envoy.downstreamTlsSdsSecret" . | nindent 4 }}
 {{- end }}

--- a/charts/governor/templates/configmap-envoy-front.yaml
+++ b/charts/governor/templates/configmap-envoy-front.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "governor.selectorLabels" . | nindent 4 }}
 data:
   envoy.yaml: |
+    {{- include "governor.envoy.node" (dict "componentName" .Values.front.name "Release" .Release) | nindent 4 }}
     admin:
       address:
         socket_address:
@@ -110,4 +111,8 @@ data:
           {{- include "governor.envoy.upstreamTls" . | nindent 10 }}
 
         {{- include "governor.envoy.apiGrpcsCluster" (dict "apiName" .Values.api.name "apiGrpcPort" .Values.api.service.grpcPort) | nindent 8 }}
+  downstream_tls_certificate.yaml: |
+    {{- include "governor.envoy.downstreamTlsSdsSecret" . | nindent 4 }}
+  upstream_validation_context.yaml: |
+    {{- include "governor.envoy.upstreamValidationContextSdsSecret" . | nindent 4 }}
 {{- end }}

--- a/charts/governor/templates/configmap-envoy-worker.yaml
+++ b/charts/governor/templates/configmap-envoy-worker.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "governor.selectorLabels" . | nindent 4 }}
 data:
   envoy.yaml: |
+    {{- include "governor.envoy.node" (dict "componentName" $w.name "Release" .Release) | nindent 4 }}
     admin:
       address:
         socket_address:
@@ -21,4 +22,6 @@ data:
 
       clusters:
         {{- include "governor.envoy.apiGrpcsCluster" (dict "apiName" .Values.api.name "apiGrpcPort" .Values.api.service.grpcPort) | nindent 8 }}
+  upstream_validation_context.yaml: |
+    {{- include "governor.envoy.upstreamValidationContextSdsSecret" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
This updates the Governor chart’s internal TLS Envoy config to use file-based SDS for mounted cert-manager Secrets.

Previously, Envoy mounted the rotated certs but continued serving stale certificates until restart. With this change, Envoy watches the mounted cert and CA files and reloads them automatically when cert-manager rotates the Secret.

### Changes

- switch Envoy TLS config from static file references to file-based SDS
- add watched directories for mounted cert and CA files
- add required Envoy node identity for SDS
- apply consistently to API, front, and worker Envoy configs

### Tested

- deployed locally on Minikube with tlsInternal.enabled=true
- rotated governor-front-tls
- verified Secret cert, mounted cert, and served cert all updated to the new serial
- verified no pod restart was needed
- checked Envoy SDS stats showed successful SSL context updates