### PR TITLE
Add SAML group-to-role mapping support in configmap and values

### DIFF
--- a/charts/governor/templates/configmap-api.yaml
+++ b/charts/governor/templates/configmap-api.yaml
@@ -45,8 +45,26 @@ data:
   {{- if .governor.authorities.defaultRole }}
   GOVERNOR_SECURITY_SAML_AUTHORITIES_DEFAULT_ROLE: {{ .governor.authorities.defaultRole | quote }}
   {{- end }}
-  {{- range $roleKey, $roleValue := .governor.authorities.roleAliases }}
-  GOVERNOR_SECURITY_SAML_AUTHORITIES_ROLE_ALIASES_{{ $roleKey | upper | replace "-" "_" }}: {{ $roleValue | quote }}
+  {{/*
+    Group-to-role mapping. Two input shapes are supported:
+
+    * `aliases` (preferred): list of {group, role} pairs. Rendered as indexed env
+      vars that bind cleanly through Spring's relaxed environment-variable rules.
+
+    * `roleAliases` (legacy): map of group→role. Cannot be expressed as
+      individual env vars because Spring's binder cannot enumerate descendants
+      of a Map property whose prefix contains a hyphen (`role-aliases`). We
+      therefore render this map as a single SPRING_APPLICATION_JSON entry,
+      which Spring loads via its JSON property source — original keys preserved.
+
+    Both shapes are merged on the application side; safe to use either or both.
+  */}}
+  {{- range $idx, $entry := .governor.authorities.aliases }}
+  GOVERNOR_SECURITY_SAML_AUTHORITIES_ALIASES_{{ $idx }}_GROUP: {{ required "saml.governor.authorities.aliases[].group is required" $entry.group | quote }}
+  GOVERNOR_SECURITY_SAML_AUTHORITIES_ALIASES_{{ $idx }}_ROLE:  {{ required "saml.governor.authorities.aliases[].role is required" $entry.role | quote }}
+  {{- end }}
+  {{- if .governor.authorities.roleAliases }}
+  SPRING_APPLICATION_JSON: {{ dict "governor" (dict "security" (dict "saml" (dict "authorities" (dict "role-aliases" .governor.authorities.roleAliases)))) | toJson | quote }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/governor/values.yaml
+++ b/charts/governor/values.yaml
@@ -223,6 +223,20 @@ api:
         groupAttribute: "groups"
         convertToUpperCase: true
         defaultRole: "MEMBER"
+        # Preferred form for env-var-driven deployments. List of group→role
+        # pairs; rendered as indexed env vars that Spring binds correctly.
+        # aliases:
+        #   - group: WM_SYNTHESIZED_ADMIN_QA
+        #     role: ADMINISTRATOR
+        #   - group: WM_SYNTHESIZED_OWNER_QA
+        #     role: OWNER
+        aliases: []
+        # Legacy map form. Rendered into SPRING_APPLICATION_JSON because Spring's
+        # relaxed binding cannot bind a Map<String, X> from individual env vars
+        # when the property prefix (`role-aliases`) contains a hyphen. Original
+        # keys are preserved.
+        # roleAliases:
+        #   WM_SYNTHESIZED_ADMIN_QA: ADMINISTRATOR
         roleAliases: {}
   # Extra volume mounts for the api container
   # extraVolumeMounts:


### PR DESCRIPTION
## Summary
Renders SAML group-to-role aliases as env vars Spring can actually bind: `aliases` list as indexed env vars, legacy `roleAliases` map wrapped in `SPRING_APPLICATION_JSON`.

## Changes
- New `aliases: []` field under `api.saml.governor.authorities`
- `aliases` rendered as `..._ALIASES_<n>_GROUP` / `..._ROLE` env vars
- Legacy `roleAliases` rendered as `SPRING_APPLICATION_JSON` (preserves keys)
- Old per-key `..._ROLE_ALIASES_<KEY>` rendering removed (never bound)
- Both shapes can coexist; merged on the application side

## Notes
- Existing values.yaml shapes keep working without changes
- Requires `governor` app version that recognizes `aliases` (introduced alongside this PR)

## Checklist
- [x] Chart renders cleanly with `aliases` only, `roleAliases` only, both, neither
- [x] `values.yaml` documents both shapes inline
- [ ] Chart version bumped