### PR TITLE
Remove dead UI_PII_SCAN flag from front config

### DIFF
--- a/charts/governor/values.yaml
+++ b/charts/governor/values.yaml
@@ -304,7 +304,6 @@ front:
       API_INTERNAL_HOST: 'governor-api'
       API_GRPC_INTERNAL_PORT: '50055'
       API_HTTP_INTERNAL_PORT: '80'
-      UI_PII_SCAN: "true"
       UI_WORKFLOW_WIZARD: "true"
     secretConfig:
       # DEPRECATED: name is missing the UI_ prefix the frontend manifest expects


### PR DESCRIPTION
## Summary
Remove `UI_PII_SCAN` from `front.container.config` in `values.yaml`

This flag was removed from the TDK backend and frontend in https://github.com/synthesized-io/tdk/pull/8612 — the PII scan feature is now always enabled. The env var is no longer read by either the API or the frontend, making it dead config

**Note:** The other 3 flags removed in that PR (`UI_VISUAL_EDITOR`, `UI_DB_VIEW`, `UI_WORKFLOW_SETTINGS`) were never present in helm-charts values, so no cleanup needed for those in this repo