### PR TITLE
Remove deprecated tdkAgents feature flag and related configurations

### DIFF
--- a/charts/governor/templates/NOTES.txt
+++ b/charts/governor/templates/NOTES.txt
@@ -44,24 +44,3 @@ cleanup of the old resources automatically).
 
 {{- end }}
 
-{{- if .Values.tdkAgents }}
-
-============================================================
-DEPRECATION WARNING — legacy `tdkAgents:` flag detected
-============================================================
-The `tdkAgents:` feature flag is DEPRECATED. It has been
-renamed to `tdkWorkers:` and will be removed in a future
-release.
-
-Your `tdkAgents:` values still take effect — they are merged
-on top of `tdkWorkers:` defaults (legacy values win on
-conflict). Do not mix the two blocks.
-
-To migrate:
-
-  tdkAgents:           ->   tdkWorkers:
-    enabled: true             enabled: true
-    useByDefault: true        useByDefault: true
-============================================================
-
-{{- end }}

--- a/charts/governor/templates/_helpers.tpl
+++ b/charts/governor/templates/_helpers.tpl
@@ -34,16 +34,6 @@ Usage: {{- $w := include "governor.workerValues" . | fromYaml }}
 {{- end -}}
 
 {{/*
-Resolve tdkWorkers feature flag with backward-compatible fallback from
-legacy "tdkAgents" key. Same merge semantics as governor.workerValues.
-*/}}
-{{- define "governor.tdkWorkersValues" -}}
-{{- $w := .Values.tdkWorkers | default dict -}}
-{{- $a := .Values.tdkAgents | default dict -}}
-{{- mustMergeOverwrite (deepCopy $w) (deepCopy $a) | toYaml -}}
-{{- end -}}
-
-{{/*
 Shared cert-manager Certificate manifest.
 
 Usage:

--- a/charts/governor/templates/configmap-api.yaml
+++ b/charts/governor/templates/configmap-api.yaml
@@ -68,9 +68,6 @@ data:
   {{- end }}
   {{- end }}
   {{- end }}
-  {{- $tdkW := include "governor.tdkWorkersValues" . | fromYaml }}
-  UI_TDK_AGENTS: {{ $tdkW.enabled | quote }}
-  UI_TDK_AGENTS_BY_DEFAULT: {{ $tdkW.useByDefault | quote }}
   {{- with .Values.s3Client }}
   {{- if .forcePathStyle }}
   TDK_S3_FORCE_PATH_STYLE: {{ .forcePathStyle | quote }}

--- a/charts/governor/templates/configmap-front.yaml
+++ b/charts/governor/templates/configmap-front.yaml
@@ -21,9 +21,6 @@ data:
 {{ toYaml .Values.front.container.config | indent 2}}
 {{- end }}
 {{- end }}
-  {{- $tdkW := include "governor.tdkWorkersValues" . | fromYaml }}
-  UI_TDK_AGENTS: {{ $tdkW.enabled | quote }}
-  UI_TDK_AGENTS_BY_DEFAULT: {{ $tdkW.useByDefault | quote }}
 {{- if .Values.analytics.posthog.apiHost }}
   UI_POSTHOG_ANALYTICS_API_HOST: {{ .Values.analytics.posthog.apiHost | quote }}
 {{- end }}

--- a/charts/governor/values.yaml
+++ b/charts/governor/values.yaml
@@ -25,11 +25,6 @@ migrationCleanup:
   # upgrade. Use this only when you do NOT need the existing worker data.
   deleteLegacyPvc: false
 
-# Feature flags shared across components.
-tdkWorkers:
-  enabled: true
-  useByDefault: true
-
 # Public host the deployment is reachable on (e.g. exp-pl8kwnr.dev-hybrid-cloud.synthesized.io).
 # Surfaces to the api pod as UI_SERVER_HOST. Required for:
 #   - PostHog analytics (forms the distinct_id namespace shared by FE/BE)
@@ -46,11 +41,8 @@ serverHost: ""
 analytics:
   posthog:
     apiKey: ""
-    apiHost: "https://eu.posthog.com"
+    apiHost: "https://eu.i.posthog.com"
 
-# DEPRECATED: legacy `tdkAgents:` overrides are merged on top of `tdkWorkers:`
-# (legacy values take precedence for any field they specify).
-# tdkAgents: {}
 s3Client:
   # forcePathStyle: true
   # protocol: "http"
@@ -304,7 +296,6 @@ front:
       API_INTERNAL_HOST: 'governor-api'
       API_GRPC_INTERNAL_PORT: '50055'
       API_HTTP_INTERNAL_PORT: '80'
-      UI_WORKFLOW_WIZARD: "true"
     secretConfig:
       # DEPRECATED: name is missing the UI_ prefix the frontend manifest expects
       # and is therefore not picked up by the FE. Use `analytics.posthog.apiKey`


### PR DESCRIPTION
This pull request removes legacy support for the deprecated `tdkAgents` feature flag in the Helm chart for Governor, fully transitioning to the `tdkWorkers` configuration. It also updates some default configuration values and cleans up unused or deprecated settings.

**Deprecation and cleanup of legacy feature flags:**

* Removed all references to the deprecated `tdkAgents` feature flag, including merging logic and deprecation warnings in templates and documentation. [[1]](diffhunk://#diff-4c403cec99bf702068f8d0c0408f7ea6eb566883f38bd8a326f9603634ebcf14L36-L45) [[2]](diffhunk://#diff-e8361cd2c1a66fa520af4e1a0907d3b33225620b0a43a3e7229531be5fd30313L47-L67) [[3]](diffhunk://#diff-ab6f3ee6dac0ede5c94906b72d75faf67d228a6190cc21c52f566820bd999951L28-L32)
* Removed the helper template `governor.tdkWorkersValues` and associated environment variables from `configmap-api.yaml` and `configmap-front.yaml` that previously handled fallback to `tdkAgents`. [[1]](diffhunk://#diff-4c403cec99bf702068f8d0c0408f7ea6eb566883f38bd8a326f9603634ebcf14L36-L45) [[2]](diffhunk://#diff-7afe56697113ef567a50c1cd642eb36fd26eb8257401378b6944b209b0cc7247L71-L73) [[3]](diffhunk://#diff-23f52ff6f3c4383593e1fd7161fa08f5dfc9aa75fda96c3439b6b293cd249dacL24-L26)

**Configuration updates:**

* Changed the default `analytics.posthog.apiHost` value to `https://eu.i.posthog.com` for improved analytics endpoint configuration.
* Removed the `UI_WORKFLOW_WIZARD` configuration from the `front.container.config` section, likely as part of unused or deprecated settings cleanup.