### PR TITLE
Disable Envoy route timeout for gRPC routes

### DIFF
--- a/charts/governor/templates/_helpers.tpl
+++ b/charts/governor/templates/_helpers.tpl
@@ -299,6 +299,9 @@ Envoy gRPC egress listener to api (shared by front and agent)
                         prefix: "/"
                       route:
                         cluster: api_grpcs
+                        # Disable route timeout: gRPC uses long-lived streams
+                        # (task updates, file transfers); Envoy's default is 15s
+                        timeout: 0s
             http_filters:
               {{- include "governor.envoy.httpRouter" . | nindent 14 }}
 {{- end }}

--- a/charts/governor/templates/configmap-envoy-api.yaml
+++ b/charts/governor/templates/configmap-envoy-api.yaml
@@ -67,6 +67,9 @@ data:
                                 prefix: "/"
                               route:
                                 cluster: local_grpc
+                                # Disable route timeout: gRPC uses long-lived streams
+                                # (task updates, file transfers); Envoy's default is 15s
+                                timeout: 0s
                     http_filters:
                       {{- include "governor.envoy.httpRouter" . | nindent 22 }}
               {{- include "governor.envoy.downstreamTls" . | nindent 14 }}


### PR DESCRIPTION
Envoy's default 15s route timeout kills long-lived gRPC streams between worker/agent and api when `tlsInternal` is enabled.

- task-update streams died every 15s (constant `UNAVAILABLE: upstream request timeout` reconnects)
- CSV uploads taking >15s failed the whole task after a successful transformation
- fix: `timeout: 0s` on all gRPC routes (api inbound, worker/front egress)
- dead connections still covered by Envoy's default 5m stream idle timeout

Verified with `helm lint` and `helm template --set tlsInternal.enabled=true` — `timeout: 0s` rendered in all three Envoy configs.